### PR TITLE
Link Updated

### DIFF
--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -2,7 +2,7 @@
 
 <div align="center"><img src="http://viayoo.com/en/images/logo.png" alt="Via Logo" height="100"/></div>
 
-English|[简体中文](https://github.com/tuyafeng/Via/blob/master/README_zh_CN.md)|[繁體中文](https://github.com/tuyafeng/Via/blob/master/README_zh_TW.md)|[Português](https://github.com/tuyafeng/Via/blob/master/README_pt_BR.md)
+[English](https://github.com/tuyafeng/Via/blob/master/README.md)|[简体中文](https://github.com/tuyafeng/Via/blob/master/README_zh_CN.md)|[繁體中文](https://github.com/tuyafeng/Via/blob/master/README_zh_TW.md)|Português
 
 ### Introdução
 

--- a/README_zh_CN.md
+++ b/README_zh_CN.md
@@ -2,7 +2,7 @@
 
 <div align="center"><img src="http://viayoo.com/en/images/logo.png" alt="Via Logo" height="100"/></div>
 
-English|[简体中文](https://github.com/tuyafeng/Via/blob/master/README_zh_CN.md)|[繁體中文](https://github.com/tuyafeng/Via/blob/master/README_zh_TW.md)|[Português](https://github.com/tuyafeng/Via/blob/master/README_pt_BR.md)
+[English](https://github.com/tuyafeng/Via/blob/master/README.md)|简体中文|[繁體中文](https://github.com/tuyafeng/Via/blob/master/README_zh_TW.md)|[Português](https://github.com/tuyafeng/Via/blob/master/README_pt_BR.md)
 
 ### 简介
 

--- a/README_zh_TW.md
+++ b/README_zh_TW.md
@@ -2,7 +2,7 @@
 
 <div align="center"><img src="http://viayoo.com/en/images/logo.png" alt="Via Logo" height="100"/></div>
 
-English|[简体中文](https://github.com/tuyafeng/Via/blob/master/README_zh_CN.md)|[繁體中文](https://github.com/tuyafeng/Via/blob/master/README_zh_TW.md)|[Português](https://github.com/tuyafeng/Via/blob/master/README_pt_BR.md)
+[English](https://github.com/tuyafeng/Via/blob/master/README.md)|[简体中文](https://github.com/tuyafeng/Via/blob/master/README_zh_CN.md)|繁體中文|[Português](https://github.com/tuyafeng/Via/blob/master/README_pt_BR.md)
 
 ### 簡介
 


### PR DESCRIPTION
在原来的版本中，[README_zh_CN.md](https://github.com/tuyafeng/Via/blob/master/README_zh_CN.md)等非英语README文件中**无法切换到英语README文件**，并且多余地添加了指向着自己的链接。（如图1所示）
![image1](https://user-images.githubusercontent.com/58388568/107135301-89708280-6934-11eb-9e6a-c0597420c550.png)


这个Pull Request修改了README_zh_CN.md、README_zh_TW.md、README_pt_BR.md文件，在这三个文件中**添加了指向README.md**（即英语版README）的链接，并且删除了指向自己的链接。（如图2所示）
![image2](https://user-images.githubusercontent.com/58388568/107135372-06036100-6935-11eb-90b9-f7785ca41a65.png)
