### PR TITLE
Add README for Spanish + Edit line 37

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ We encourage everyone to help with localization. The following is how to do.
 
 **Which rendering engine does Via use?**
 
-Via uses the built-in WebView renderer included on the Android platform. On Android 5.0+ devices, the WebView implementation is usually `Android System WebView (com.google.android.webview)`, you can update it in the Play Store for a better browsing experience. If you want to know the current WebView implementation and version of your device, you can click "Settings - About - Version" of Via to get the debugging information which contains the WebView information.
+Via uses the built-in WebView renderer included on the Android platform. On Android 5.0+ devices, the WebView implementation is usually `Android System WebView (com.google.android.webview)`, you can update it in the Play Store for a better browsing experience. If you want to know the current WebView implementation and version of your device, you can click "Settings - About" in Via and tap on the Via logo to get the debugging information which contains the WebView information.
 
 **How to disable JavaScript or set a special user agent for a website?**
 

--- a/README_es.md
+++ b/README_es.md
@@ -1,0 +1,64 @@
+# Via Browser - La Mejor Opción del Geek
+
+<div align="center"><img src="http://viayoo.com/en/images/logo.png" alt="Via Logo" height="100"/></div>
+
+[English](https://github.com/tuyafeng/Via/blob/master/README.md) | [简体中文](https://github.com/tuyafeng/Via/blob/master/README_zh_CN.md) | [繁體中文](https://github.com/tuyafeng/Via/blob/master/README_zh_TW.md) | [Português](https://github.com/tuyafeng/Via/blob/master/README_pt_BR.md) | Español
+
+### Introducción
+
+Via Browser es un poderoso navegador que cuenta con las siguientes características:
+
+- Puro y sin publicidad
+- Altamente personalizable
+- Veloz como un relámpago
+- Pequeño, pero asombroso
+
+Pruébalo y jamás te arrepentirás :)
+
+[Consíguelo en Google Play](https://play.google.com/store/apps/details?id=mark.via.gp)
+
+[Descarga la versión global](https://res.viayoo.com/v1/via-release.apk)
+
+[Descarga la versión china](https://res.viayoo.com/v1/via-release-cn.apk)
+
+### Ayuda con la localización
+
+Alentamos a todo el mundo a ayudarnos con la localización/traducción. A continuación se explica cómo:
+
+1. Crea un fork de este repositorio
+2. Copia el archivo `app/src/main/res/values/strings.xml` y cambia su dirección a `app/src/main/res/values-%(lang)/`, reemplaza `%(lang)` con [*el código ISO 639-1 del lenguaje al que traducirás todo*](http://www.loc.gov/standards/iso639-2/php/code_list.php)
+3. Traduce el archivo `app/src/main/res/values-%(lang)/strings.xml`
+4. Crea una pull request
+
+### Preguntas Frecuentes
+
+**¿Qué motor de renderizado utiliza Via?**
+
+Via utiliza el procesador WebView integrado en la plataforma Android. En dispositivos Android 5.0+, la implementación de WebView usualmente es `Android System WebView (com.google.android.webview)`, puedes actualizarla en la Play Store para una mejor experiencia de navegación. Si quieres saber cuál es la implementación actual de WebView y la versión de tu dispositivo, en Via puedes ir a "Ajustes - Acerca de" y presionar el logo de Via para ver la información de debugging, la cual contiene la información de WebView.
+
+**¿Cómo se desactiva el JavaScript o se ajusta un agente de usuario para un sitio en específico?**
+
+Abre el sitio, presiona la lupa/ícono de escudo a la izquierda de la barra del navegador y en "Configuración del sitio" puedes hacer los ajustes para la página.
+
+O abre "Ajustes - General - Configuración del sitio" para realizar la configuración manualmente.
+
+**No quiero bloquear publicidad en un sitio específico.**
+
+Por favor dirigirse a la pregunta anterior. Puedes desactivar el adblock para el sitio en "Configuración del sitio".
+
+**¿Por qué Via no guardar contraseñas?**
+
+Desafortunadamente, Google removió esta función de WebView en particular. Puedes intentar utilizar aplicaciones con auto-rellenado (Bitwarden, KeePass, etc.) si la versión de Android de tu dispositivo es mayor o igual a 8.0.
+
+**¿Por qué Via no escanea códigos QR?**
+
+Hay muchas aplicaciones que escanean códigos QR y no quiero agregar una función tan repetitiva. Puedes escanear el código QR con la aplicación de cámara de tu teléfono.
+
+**¿Cómo puedo contactarte?**
+
+Puedes contactarme en [Twitter](https://twitter.com/Yafeng78600505) y responderé tan pronto como sea posible.
+
+También puedes [abrir una issue](https://github.com/tuyafeng/Via/issues/new) en GitHub, chequearé y responderé a las issues más o menos una vez a la semana.
+
+Puedes escribirme un correo [aquí](mailto:yafengtu@gmail.com) si lo amerita, pero lamentablemente puede que no responda.
+

--- a/README_es.md
+++ b/README_es.md
@@ -34,7 +34,7 @@ Alentamos a todo el mundo a ayudarnos con la localización/traducción. A contin
 
 **¿Qué motor de renderizado utiliza Via?**
 
-Via utiliza el procesador WebView integrado en la plataforma Android. En dispositivos Android 5.0+, la implementación de WebView usualmente es `Android System WebView (com.google.android.webview)`, puedes actualizarla en la Play Store para una mejor experiencia de navegación. Si quieres saber cuál es la implementación actual de WebView y la versión de tu dispositivo, en Via puedes ir a "Ajustes - Acerca de" y presionar el logo de Via para ver la información de debugging, la cual contiene la información de WebView.
+Via utiliza el procesador WebView integrado en la plataforma Android. En dispositivos Android 5.0+, la implementación de WebView usualmente es `Android System WebView (com.google.android.webview)`, puedes actualizarla en la Play Store para una mejor experiencia de navegación. Si quieres saber cuál es la implementación actual de WebView y la versión de tu dispositivo, en Via puedes ir a "Ajustes - Acerca de" y presionar el logo de Via para ver la información de depuración, la cual contiene la información de WebView.
 
 **¿Cómo se desactiva el JavaScript o se ajusta un agente de usuario para un sitio en específico?**
 

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -2,7 +2,7 @@
 
 <div align="center"><img src="http://viayoo.com/en/images/logo.png" alt="Via Logo" height="100"/></div>
 
-[English](https://github.com/tuyafeng/Via/blob/master/README.md) | [简体中文](https://github.com/tuyafeng/Via/blob/master/README_zh_CN.md) | [繁體中文](https://github.com/tuyafeng/Via/blob/master/README_zh_TW.md) | Português | [Español Castellano](https://github.com/tuyafeng/Via/blob/master/README_es.md)
+[English](https://github.com/tuyafeng/Via/blob/master/README.md) | [简体中文](https://github.com/tuyafeng/Via/blob/master/README_zh_CN.md) | [繁體中文](https://github.com/tuyafeng/Via/blob/master/README_zh_TW.md) | Português | [Español](https://github.com/tuyafeng/Via/blob/master/README_es.md)
 
 ### Introdução
 

--- a/README_pt_BR.md
+++ b/README_pt_BR.md
@@ -2,7 +2,7 @@
 
 <div align="center"><img src="http://viayoo.com/en/images/logo.png" alt="Via Logo" height="100"/></div>
 
-[English](https://github.com/tuyafeng/Via/blob/master/README.md) | [简体中文](https://github.com/tuyafeng/Via/blob/master/README_zh_CN.md) | [繁體中文](https://github.com/tuyafeng/Via/blob/master/README_zh_TW.md) | Português
+[English](https://github.com/tuyafeng/Via/blob/master/README.md) | [简体中文](https://github.com/tuyafeng/Via/blob/master/README_zh_CN.md) | [繁體中文](https://github.com/tuyafeng/Via/blob/master/README_zh_TW.md) | Português | [Español Castellano](https://github.com/tuyafeng/Via/blob/master/README_es.md)
 
 ### Introdução
 


### PR DESCRIPTION
Besides adding a spanish version of the README, I also corrected (both in the Spanish and English READMEs) line 37, which had incorrect information: 

> you can click "Settings - About - Version" of Via to get the debugging information

There's no "Version" section after "Settings - About". The only way to reveal the debugging info is to click the Via logo at the top.
<details>
<summary>About section before tapping logo</summary>
<img src="https://user-images.githubusercontent.com/65634520/147302069-24a4faa8-62ac-4e60-b10b-a27677f2e54b.png" width="500"></img>
</details>
<details>
<summary>About section after tapping logo</summary>
<img src="https://user-images.githubusercontent.com/65634520/147302256-d3e6f245-2b59-4a51-b5a0-febcbe168045.png" width="500"></img>
</details>

This still needs to be corrected on the Portuguese and Mandarin READMEs.
