### PR TITLE
Fix a few errors in English strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -440,14 +440,14 @@
     <string name="clear_website_icon_cache_message">Note that this will clear all the favorite icons on the homepage. Each icon will be downloaded the next time you visit the corresponding website.</string>
     <string name="use_blur_instead_of_transparency">Use blur effect instead of transparency</string>
     <string name="desc_favorite_icon">Icon of a favorite</string>
-    <string name="script_remarks">Remarks</string>
+    <string name="script_remarks">Note</string>
     <string name="action_save">Save</string>
     <string name="reset_to_default_settings">Reset to default settings</string>
     <string name="script_sites">Sites (like *.foo.com,bar.*/list)</string>
     <string name="simple_guide_of_writing_script">The script written will take effect automatically when the website loads.
-    \n\nSites(required): The scripted site supports the \"*\" wildcard, and multiple sites are separated by \",\", for example: *.foo.com,bar.*/list.
-    \n\nRemarks(optional): Used as the title of the display.
-    \n\nCode(required): It is recommended to use native JavaScript. You can also use jquery or vue.js syntax if the website uses those frameworks.</string>
+    \n\nSites (required): The scripted site supports the \"*\" wildcard, and multiple sites are separated by \",\", for example: *.foo.com,bar.*/list.
+    \n\nNote (optional): Used as the title of the script.
+    \n\nCode (required): It is recommended to use native JavaScript. You can also use jquery or vue.js syntax if the website uses those frameworks.</string>
     <string name="save_data">Save data</string>
     <string name="save_data_description">Enable data-savings mode on compatible websites</string>
     <string name="use_line_style_search_box">Use line style search box</string>
@@ -459,7 +459,7 @@
     <string name="new_version_available">New version available</string>
     <string name="action_download_file">Download</string>
     <string name="entered_full_screen_mode">Entered full screen mode</string>
-    <string name="delete_hint">Delete(%1$d)</string>
+    <string name="delete_hint">Delete (%1$d)</string>
     <string name="follow_system_dark_mode_on">Follow system dark mode is enabled</string>
     <string name="scoped_search">Search %1$s</string>
     <string name="add_shortcut">Add shortcut</string>
@@ -497,7 +497,7 @@
     <string name="no_certificate">The website does not have a certificate.</string>
     <string name="site_conf_enabled">Site configuration (Enabled)</string>
     <string name="do_not_sell_or_share">Do not sell or share data</string>
-    <string name="do_not_sell_or_share_description">Require the website not to sell or share my data to protect privacy (experimental)</string>
+    <string name="do_not_sell_or_share_description">Request the website not to sell or share my data to protect privacy (experimental)</string>
     <string name="email_me">Email me</string>
     <string name="scan_qr_code">Scan QR code</string>
     <string name="scan_qr_code_from_image">Scan QR code from image</string>
@@ -513,7 +513,7 @@
     <string name="delete_history_from">Delete history from</string>
     <string name="save_as_pdf">Save as PDF</string>
     <string name="export">Export</string>
-    <string name="export_successfully">Export successfully</string>
+    <string name="export_successfully">Exported successfully</string>
     <string name="stop_loading_description">Via has prevented the following page from loading:</string>
     <string name="stop_loading_reason">Because of the following filter:</string>
     <string name="continue_loading">Continue loading</string>


### PR DESCRIPTION
I've fixed a few terminology (and smaller ortography) errors I've found in English strings:
- "remarks" isn't really appropriate in this context. ["remark" is a synonym of "notice", "observation"](https://en.wiktionary.org/wiki/remark), for example a comment made to something that someone else said.
- "require" implies some form of constraint/obligation for the subject of the requirement. This doesn't seem to be the case to me, also given that DeepL chooses the verb "Request" [when translating the original Chinese string](https://www.deepl.com/translator#zh/en/%E8%AF%B7%E6%B1%82%E7%BD%91%E7%AB%99%E4%B8%8D%E5%87%BA%E5%94%AE%E6%88%96%E5%88%86%E4%BA%AB%E6%88%91%E7%9A%84%E6%95%B0%E6%8D%AE%E4%BB%A5%E4%BF%9D%E6%8A%A4%E9%9A%90%E7%A7%81).